### PR TITLE
Feat NIP-32 Language Compatibility Support

### DIFF
--- a/nip32-transform.ts
+++ b/nip32-transform.ts
@@ -17,3 +17,12 @@ export function transformNip32ContentSafetyToLegacyFormat(classificationData: an
 
   return finalClassificationData;
 }
+
+// A workaround while deprecating legacy format. This function will be adjusted when NIP-32 fully implemented properly.
+export function transformNip32LanguageToLegacyFormat(classificationData: any[][]) {
+  let finalClassificationData = [];
+  for (const classification of classificationData) {
+    finalClassificationData.push({ confidence: classification[3], language: classification[1] })
+  }
+  return finalClassificationData;
+}


### PR DESCRIPTION
Initial implementation to support NIP-32 format (kind: 1985) for language label (Language classification) while deprecating legacy custom format (kind: 9978).

Partial solution for issue #35 .