### PR TITLE
Feat NIP-32 Toxicity Compatibility Support

### DIFF
--- a/nip32-transform.ts
+++ b/nip32-transform.ts
@@ -26,3 +26,12 @@ export function transformNip32LanguageToLegacyFormat(classificationData: any[][]
   }
   return finalClassificationData;
 }
+
+// A workaround while deprecating legacy format. This function will be adjusted when NIP-32 fully implemented properly.
+export function transformNip32ToxicityToLegacyFormat(classificationData: any[][]) {
+  let finalClassificationData: any = {};
+  for (const classification of classificationData) {
+    finalClassificationData[classification[1]] = classification[3];
+  }
+  return finalClassificationData;
+}


### PR DESCRIPTION
Initial implementation to support NIP-32 format (kind: 1985) for toxicity label (Toxicity classification) while deprecating legacy custom format (kind: 9978).

Partial solution for issue  #35 .