### PR TITLE
Feat NIP-32 Sentiment Compatibility Support

### DIFF
--- a/nip32-transform.ts
+++ b/nip32-transform.ts
@@ -35,3 +35,12 @@ export function transformNip32ToxicityToLegacyFormat(classificationData: any[][]
   }
   return finalClassificationData;
 }
+
+// A workaround while deprecating legacy format. This function will be adjusted when NIP-32 fully implemented properly.
+export function transformNip32SentimentToLegacyFormat(classificationData: any[][]) {
+  let finalClassificationData: any = {};
+  for (const classification of classificationData) {
+    finalClassificationData[classification[1]] = classification[3];
+  }
+  return finalClassificationData;
+}


### PR DESCRIPTION
Initial implementation to support NIP-32 format (kind: 1985) for sentiment label (Sentiment classification) while deprecating legacy custom format (kind: 9978).

Partial solution for issue #35 .