### PR TITLE
Feat NIP-32 Topic Classification Compatibility Support

### DIFF
--- a/nip32-transform.ts
+++ b/nip32-transform.ts
@@ -44,3 +44,12 @@ export function transformNip32SentimentToLegacyFormat(classificationData: any[][
   }
   return finalClassificationData;
 }
+
+// A workaround while deprecating legacy format. This function will be adjusted when NIP-32 fully implemented properly.
+export function transformNip32TopicToLegacyFormat(classificationData: any[][]) {
+  let finalClassificationData = [];
+  for (const classification of classificationData) {
+    finalClassificationData.push({ score: classification[3], label: classification[1] })
+  }
+  return finalClassificationData;
+}


### PR DESCRIPTION
Initial implementation to support NIP-32 format (kind: 1985) for topic label (Topic classification) while deprecating legacy custom format (kind: 9978).

Partial solution for issue #35 .